### PR TITLE
[fix] fix argument must be str, not bytes Error on write_file

### DIFF
--- a/mbdirector/benchmark.py
+++ b/mbdirector/benchmark.py
@@ -54,10 +54,7 @@ class Benchmark(object):
         return cls(config, **json)
 
     def write_file(self, name, data):
-        mode = 'w'
-        if type(data)==bytes:
-            mode = 'wb'
-        with open(os.path.join(self.config.results_dir, name), mode) as outfile:
+        with open(os.path.join(self.config.results_dir, name), 'wb') as outfile:
             outfile.write(data)
 
     def run(self):

--- a/mbdirector/benchmark.py
+++ b/mbdirector/benchmark.py
@@ -54,7 +54,10 @@ class Benchmark(object):
         return cls(config, **json)
 
     def write_file(self, name, data):
-        with open(os.path.join(self.config.results_dir, name), 'w') as outfile:
+        mode = 'w'
+        if type(data)==bytes:
+            mode = 'wb'
+        with open(os.path.join(self.config.results_dir, name), mode) as outfile:
             outfile.write(data)
 
     def run(self):


### PR DESCRIPTION
to prevent the following error:
```
[ERROR]
	Unhandled exception: write() argument must be str, not bytes
Traceback (most recent call last):
  File "/home/runner/.local/lib/python3.5/site-packages/RLTest/__main__.py", line 496, in _runTest
    fn()
  File "/home/runner/.local/lib/python3.5/site-packages/RLTest/__main__.py", line 484, in <lambda>
    fn = lambda: test.target(env)
  File "/home/runner/work/memtier_benchmark/memtier_benchmark/tests/tests_oss_simple_flow.py", line 31, in test_default_set_get
    memtier_ok = benchmark.run()
  File "/home/runner/.local/lib/python3.5/site-packages/mbdirector/benchmark.py", line 68, in run
    self.write_file('mb.stderr', _stderr)
  File "/home/runner/.local/lib/python3.5/site-packages/mbdirector/benchmark.py", line 58, in write_file
    outfile.write(data)
TypeError: write() argument must be str, not bytes
```